### PR TITLE
added --skip-trace-on-missing-frame and --skip-sleep

### DIFF
--- a/stackcollapse_hpl.py
+++ b/stackcollapse_hpl.py
@@ -135,7 +135,7 @@ def main(argv=None, out=sys.stdout):
                 args.discard_lineno,
                 args.shorten_pkgs
             ))
-        if skip_trace == True:
+        if skip_trace:
             continue
 
         if not args.discard_thread:


### PR DESCRIPTION
Sometimes Honest-profiler generates a broken hpl that contains missing frames within a trace.  `--skip-trace-on-missing-frame` skips those frames instead of crashing.

Also I did not like how much space `java.lang.Thread.sleep` methods were taking up, so I added `--skip-sleep` to remove them.
