### PR TITLE
deal the issue of marker is 4

### DIFF
--- a/stackcollapse_hpl.py
+++ b/stackcollapse_hpl.py
@@ -73,8 +73,11 @@ def parse_hpl(filename):
             (marker,) = struct.unpack('>b', marker_str)
             if marker == 0:
                 break
-            elif marker == 1:
+            elif marker == 1 or marker == 11:
                 (frame_count, thread_id) = struct.unpack('>iQ', fh.read(4 + 8))
+                # marker is 11, read the time
+                if marker == 11:
+                    (time_sec, time_nano) = struct.unpack('>QQ', fh.read(8+8))
                 if frame_count > 0:
                     traces.append(Trace(thread_id, frame_count, []))
                 else:  # Negative frame_count are used to report error
@@ -99,6 +102,9 @@ def parse_hpl(filename):
                 class_name = parse_hpl_string(fh)
                 method_name = parse_hpl_string(fh)
                 methods[method_id] = Method(method_id, file_name, class_name, method_name)
+            elif marker == 4: # 4 means thread meta, not useful in flame graph
+                (thread_id,) = struct.unpack('>Q', fh.read(8))
+                thread_name = parse_hpl_string(fh)
             else:
                 raise Exception("Unexpected marker: %s at offset %s" % (marker, fh.tell()))
 


### PR DESCRIPTION
I encountered exception "Unexpected marker: 4 at offset 1" when I used stackcollapse_hprof.py to convert honest-profiler  file to flame graph format. I found the reason is that the updated honest-profiler uses 4 as the marker of thread meta. And I also found the marker of 11 is not supported in stackcollapse_hprof.py,so I add  code to deal with this situation.