### PR TITLE
UnicodeEncodeError occurred.

### DIFF
--- a/stackcollapse_hprof.py
+++ b/stackcollapse_hprof.py
@@ -198,7 +198,7 @@ def main(argv=None, out=sys.stdout):
         sys.exit('Failed to get samples.')
 
     for line in to_flamegraph(stacks, counts):
-        print(line, file=out)
+        print(line.encode('utf-8'), file=out)
 
     return 0
 


### PR DESCRIPTION
UnicodeEncodeError occurred when collapsed result append to file as like below
---
./stackcollapse_hprof_original.py out.hprof > collapsed.txt
Traceback (most recent call last):
  File "./stackcollapse_hprof_original.py", line 207, in <module>
    main()
  File "./stackcollapse_hprof_original.py", line 201, in main
    print(line, file=out)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0101' in position 704: ordinal not in range(128)

My operating system is Mac OS.
I expect collapsed result is not encoded to utf-8.
So I tried just encode each of result line. After do this it's working well.